### PR TITLE
chore: add Helm Chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,13 @@ jobs:
           ref: dev
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-
       - name: 🛤️ Version tag must be on dev branch
         if: github.event_name == 'push'
         run: git branch --contains ${{ github.ref }} | grep dev
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
 
       - name: ⬆️ Bump version
         if: github.event_name == 'workflow_dispatch'
@@ -54,6 +54,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           npx bumpp ${{ env[inputs.version] }} -y -r --commit "chore(release): v%s"
+
+          VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+          sed -E "s/^appVersion:.+$/appVersion: '$VERSION'/" -i install/kubernetes/github-actions-cache-server/Chart.yaml
+          git commit --amend --no-edit
 
           echo "RELEASE_REF=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ dist/
 pnpm-lock.yaml
 data/
 docs/content/**/*.md
+install/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,7 @@ export default eslintConfig({
   })
   .append({
     ignores: [
-      "install/**/*.*",
+      'install/',
       '.prettierrc.cjs',
       '.lintstagedrc.mjs',
       'node_modules/',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ export default eslintConfig({
   })
   .append({
     ignores: [
+      "install/**/*.*",
       '.prettierrc.cjs',
       '.lintstagedrc.mjs',
       'node_modules/',

--- a/install/kubernetes/github-actions-cache-server/.helmignore
+++ b/install/kubernetes/github-actions-cache-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/install/kubernetes/github-actions-cache-server/Chart.yaml
+++ b/install/kubernetes/github-actions-cache-server/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.0.0"
+appVersion: '4.0.1'

--- a/install/kubernetes/github-actions-cache-server/Chart.yaml
+++ b/install/kubernetes/github-actions-cache-server/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: github-actions-cache-server
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.0"

--- a/install/kubernetes/github-actions-cache-server/templates/NOTES.txt
+++ b/install/kubernetes/github-actions-cache-server/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "github-actions-cache-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "github-actions-cache-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "github-actions-cache-server.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "github-actions-cache-server.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:3000 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 3000:$CONTAINER_PORT
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/_helpers.tpl
+++ b/install/kubernetes/github-actions-cache-server/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "github-actions-cache-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "github-actions-cache-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "github-actions-cache-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "github-actions-cache-server.labels" -}}
+helm.sh/chart: {{ include "github-actions-cache-server.chart" . }}
+{{ include "github-actions-cache-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "github-actions-cache-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "github-actions-cache-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-actions-cache-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "github-actions-cache-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
@@ -1,0 +1,90 @@
+{{ $name := include "github-actions-cache-server.fullname" . }}
+{{ $internalApiBaseUrl := printf "http://%s.%s.svc.cluster.local" $name .Release.Namespace }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- with .Values.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "github-actions-cache-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "github-actions-cache-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "github-actions-cache-server.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: "/tmp"
+          {{- if .Values.persistentVolumeClaim.enabled }}
+            - name: cache-data
+              mountPath: "/app/.data"
+          {{- end }}
+          env:
+            - name: PORT
+              value: "3000"
+            - name: API_BASE_URL
+              value: {{ default $internalApiBaseUrl .Values.apiBaseUrl }}
+          {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp
+      {{- toYaml .Values.tmpVolume | nindent 10 }}
+      {{- if .Values.persistentVolumeClaim.enabled }}
+        - name: cache-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistentVolumeClaim.template.metadata.name }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/hpa.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "github-actions-cache-server.fullname" . }}
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "github-actions-cache-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/ingress.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "github-actions-cache-server.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/persistentvolumeclaim.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.persistentVolumeClaim.enabled -}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+{{ .Values.persistentVolumeClaim.template | toYaml }}
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/service.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-actions-cache-server.fullname" . }}
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "github-actions-cache-server.selectorLabels" . | nindent 4 }}

--- a/install/kubernetes/github-actions-cache-server/templates/serviceaccount.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "github-actions-cache-server.serviceAccountName" . }}
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/install/kubernetes/github-actions-cache-server/templates/tests/test-connection.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "github-actions-cache-server.fullname" . }}-test-connection"
+  labels:
+    {{- include "github-actions-cache-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "github-actions-cache-server.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/install/kubernetes/github-actions-cache-server/values.yaml
+++ b/install/kubernetes/github-actions-cache-server/values.yaml
@@ -1,0 +1,134 @@
+# Default values for github-actions-cache-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+strategy:
+  type: Recreate
+
+image:
+  repository: ghcr.io/falcondev-oss/github-actions-cache-server
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 640Mi
+  requests:
+    cpu: 500m
+    memory: 640Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 70
+
+persistentVolumeClaim:
+  enabled: true
+  template:
+    metadata:
+      name: cache-data
+      labels: {}
+      annotations: {}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+      volumeMode: Filesystem
+      # storageClassName: standard
+
+tmpVolume:
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          type: github-actions-cache-server-tmp
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        # storageClassName: standard
+        resources:
+          requests:
+            storage: 2Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+apiBaseUrl: ""
+
+env:
+  - name: DEBUG
+    value: "true"
+extraEnv:
+  - name: URL_ACCESS_TOKEN
+    value: changeme
+    # valueFrom:
+    #   secretKeyRef:
+    #     name: url-access-token
+    #     key: token

--- a/install/kubernetes/github-actions-cache-server/values.yaml
+++ b/install/kubernetes/github-actions-cache-server/values.yaml
@@ -11,11 +11,11 @@ image:
   repository: ghcr.io/falcondev-oss/github-actions-cache-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: ''
 
 imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -26,7 +26,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  name: ''
 
 podAnnotations: {}
 podLabels: {}
@@ -46,8 +46,9 @@ service:
 
 ingress:
   enabled: false
-  className: ""
-  annotations: {}
+  className: ''
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -120,11 +121,11 @@ tolerations: []
 
 affinity: {}
 
-apiBaseUrl: ""
+apiBaseUrl: ''
 
 env:
   - name: DEBUG
-    value: "true"
+    value: 'true'
 extraEnv:
   - name: URL_ACCESS_TOKEN
     value: changeme


### PR DESCRIPTION
### feat: Add Helm Chart for GitHub Actions Cache Server

This PR introduces a Helm chart for deploying a GitHub Actions cache server on Kubernetes. With this addition, setting up a local or production-ready cache server for GitHub Actions becomes straightforward and easily manageable via Kubernetes.

#### Key Features

- **Helm Chart**: Simplifies the deployment process of the GitHub Actions cache server onto any Kubernetes cluster.
- **Namespace Support**: The chart installs the cache server into a dedicated namespace (`github-actions`) to ensure clean and organized deployments.
- **Local Development**: Supports easy local Kubernetes cluster setups with `kind` for development and testing.

#### Quick Start

To quickly get started with a local Kubernetes setup using `kind`:

1. **Install `kind`**:
```bash
brew install kind
```

2. **Create a local Kubernetes cluster**:
```bash
kind create cluster
```

3. **Install the cache server with Helm**:
```bash
helm upgrade --install cache -n github-actions --create-namespace --set fullnameOverride=cache install/kubernetes/github-actions-cache-server
```

4. **Access the Cache Server Locally**:
Run the following commands to forward the cache server port to your local machine:

```bash
export POD_NAME=$(kubectl get pods --namespace github-actions -l "app.kubernetes.io/name=github-actions-cache-server,app.kubernetes.io/instance=cache" -o jsonpath="{.items[0].metadata.name}")
export CONTAINER_PORT=$(kubectl get pod --namespace github-actions $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
kubectl --namespace github-actions port-forward $POD_NAME 3000:$CONTAINER_PORT
```

#### Releasing a New Helm Chart

To release a new version of the Helm chart, follow these steps:

1. **Update the `Chart.yaml` Version:**
Before packaging the Helm chart, ensure that the `version` field in the `Chart.yaml` file is updated to the new release version. For example:

```yaml
apiVersion: v2
name: github-actions-cache-server
version: 0.1.0 # Update this version
```

Make sure to replace `0.1.0` with the new version number for the release.

2. **Package the Helm Chart:**
Once the `Chart.yaml` is updated, package the Helm chart by navigating to the directory containing your Helm chart and running the following command:

```bash
helm package install/kubernetes/github-actions-cache-server
```

This will create a `.tgz` package file for your Helm chart.

3. **Push the Helm Chart to the OCI Registry:**
After packaging, use the `helm push` command to upload the packaged Helm chart to the OCI registry. Make sure to use the correct version number that matches the one in `Chart.yaml`:

```bash
helm push github-actions-cache-server-0.1.0.tgz oci://ghcr.io/falcondev-oss
```

Replace `0.1.0` with the actual version number you're releasing.

Ensure you have the appropriate permissions to push to the specified OCI registry.

#### Notes

- This setup is ideal for local development and testing. For production environments, please adjust the Helm install command and configurations according to your specific needs.
- Feedback and contributions are welcome to enhance this chart further!

Looking forward to your reviews and suggestions!

