### PR TITLE
Allow the AWS SDK to get auth from the environment (fixes #28)

### DIFF
--- a/docs/content/2.storage-drivers/s3.md
+++ b/docs/content/2.storage-drivers/s3.md
@@ -62,12 +62,7 @@ services:
 
       STORAGE_DRIVER: s3
       STORAGE_S3_BUCKET: gh-actions-cache
-      STORAGE_S3_ACCESS_KEY: access_key
-      STORAGE_S3_SECRET_KEY: secret_key
 
-      STORAGE_S3_ENDPOINT: s3.amazonaws.com
-      STORAGE_S3_PORT: '443'
-      STORAGE_S3_USE_SSL: 'true'
     volumes:
       - cache-data:/app/.data
 
@@ -79,35 +74,19 @@ volumes:
 
 Don't forget to set the `STORAGE_DRIVER` environment variable to `s3` to use the S3 storage driver.
 
+The AWS SDK will automatically use any AWS credentials available in the environment, e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`.
+
 #### `STORAGE_S3_BUCKET`
 
 Example: `gh-actions-cache`
 
 The name of the S3 bucket used for storage.
 
-#### `STORAGE_S3_ACCESS_KEY`
-
-Example: `access_key`
-
-The access key for S3 storage.
-
-#### `STORAGE_S3_SECRET_KEY`
-
-Example: `secret_key`
-
-The secret key for S3 storage.
-
 #### `STORAGE_S3_ENDPOINT`
 
 Example: `s3.amazonaws.com`, `minio`
 
 The endpoint hostname for S3 storage.
-
-#### `STORAGE_S3_REGION`
-
-Example: `us-west-1`
-
-The region for AWS S3. Not needed with MinIO.
 
 #### `STORAGE_S3_PORT`
 

--- a/lib/storage/drivers/s3.ts
+++ b/lib/storage/drivers/s3.ts
@@ -17,24 +17,36 @@ import { streamToBuffer } from '~/lib/utils'
 export const s3Driver = defineStorageDriver({
   envSchema: z.object({
     STORAGE_S3_BUCKET: z.string().min(1),
-    STORAGE_S3_ENDPOINT: z.string().min(1),
-    STORAGE_S3_REGION: z.string().min(1).default('us-east-1'),
-    STORAGE_S3_PORT: z.coerce.number().positive(),
-    STORAGE_S3_USE_SSL: z.string().transform((v) => v === 'true'),
-    STORAGE_S3_ACCESS_KEY: z.string().min(1),
-    STORAGE_S3_SECRET_KEY: z.string().min(1),
+    STORAGE_S3_ENDPOINT: z.string().optional(),
+    STORAGE_S3_REGION: z.string().min(1).default('us-east-1').optional(),
+    STORAGE_S3_PORT: z.coerce.number().positive().optional(),
+    STORAGE_S3_USE_SSL: z
+      .string()
+      .transform((v) => v === 'true')
+      .optional(),
+    STORAGE_S3_ACCESS_KEY: z.string().optional(),
+    STORAGE_S3_SECRET_KEY: z.string().optional(),
+    AWS_REGION: z.string().optional(),
+    AWS_DEFAULT_REGION: z.string().optional(),
   }),
   async setup(options) {
     const protocol = options.STORAGE_S3_USE_SSL ? 'https' : 'http'
     const port = options.STORAGE_S3_PORT ? `:${options.STORAGE_S3_PORT}` : ''
+    let credentials
 
-    const s3 = new S3Client({
-      credentials: {
+    if (options.STORAGE_S3_ACCESS_KEY && options.STORAGE_S3_SECRET_KEY) {
+      credentials = {
         secretAccessKey: options.STORAGE_S3_SECRET_KEY,
         accessKeyId: options.STORAGE_S3_ACCESS_KEY,
-      },
-      endpoint: `${protocol}://${options.STORAGE_S3_ENDPOINT}${port}`,
-      region: options.STORAGE_S3_REGION,
+      }
+    }
+
+    const s3 = new S3Client({
+      credentials,
+      endpoint: options.STORAGE_S3_ENDPOINT
+        ? `${protocol}://${options.STORAGE_S3_ENDPOINT}${port}`
+        : undefined,
+      region: options.AWS_REGION ?? options.AWS_DEFAULT_REGION ?? options.STORAGE_S3_REGION,
       forcePathStyle: true,
     })
 


### PR DESCRIPTION
The AWS SDK can automatically gather auth from various sources in the environment, but this couldn't happen because the zod schema validation would throw if you didn't provide `STORAGE_S3_ACCESS_KEY` and `STORAGE_S3_SECRET_KEY`.

This PR makes several of the env vars optional, and deprecates them in favour of the env vars AWS SDK will infer by default.

I've tested these changes in my EKS cluster with IRSA set up for the pod to assume a role for S3 access, and it seems to work as expected.

Fixes #28