### PR TITLE
fix(docs): use correct env var name for cache cleanup

### DIFF
--- a/docs/content/1.getting-started/1.index.md
+++ b/docs/content/1.getting-started/1.index.md
@@ -58,7 +58,7 @@ variant: subtle
 ---
 ::
 
-#### `CLEANUP_OLDER_THAN_DAYS`
+#### `CACHE_CLEANUP_OLDER_THAN_DAYS`
 
 - Default: `90`
 


### PR DESCRIPTION
According to https://github.com/falcondev-oss/github-actions-cache-server/blob/dev/lib/env.ts#L9