### PR TITLE
Release Helm Chart as OCI artifact, basic installation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
 
           npx changelogithub
 
-  deploy:
-    name: 🚀 Build and push
+  deploy-docker:
+    name: 🚀 Build and push Docker image
     permissions:
       packages: write
       contents: read
@@ -136,3 +136,36 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  deploy-chart:
+    name: 🚀 Build and push Helm chart
+    permissions:
+      packages: write
+      contents: read
+    needs: [release]
+    runs-on: ubuntu-latest
+    env:
+      CHART_DIR: install/kubernetes/github-actions-cache-server
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package Helm chart
+        run: helm package . --destination packaged
+        working-directory: ${{ env.CHART_DIR }}
+
+      - name: Push Helm chart to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in ${{ env.CHART_DIR }}/packaged/*.tgz; do
+            echo "Pushing $pkg to ghcr.io/${{ github.repository_owner }}/charts"
+            helm push "$pkg" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+          done

--- a/docs/content/1.getting-started/1.index.md
+++ b/docs/content/1.getting-started/1.index.md
@@ -7,6 +7,8 @@ The cache server is available as a Docker image and can be deployed via Docker C
 
 ## 1. Deploying the Cache Server
 
+### Using Docker Compose
+
 ```yaml [docker-compose.yml]
 services:
   cache-server:
@@ -20,6 +22,48 @@ services:
 
 volumes:
   cache-data:
+```
+
+### Using Kubernetes with Helm
+
+You can deploy the cache server in Kubernetes using the Helm chart hosted in a OCI repository.
+
+#### Prerequisites
+
+- Helm version 3.8.0 or later (required for OCI support).
+- A running Kubernetes cluster.
+
+#### Steps
+
+1. Install the Helm chart:
+
+```bash
+helm install <release-name> oci://ghcr.io/falcondev-oss/charts/github-actions-cache-server
+```
+
+Replace `<release-name>` with your desired release name (e.g., `cache-server`). This will deploy the cache server with all default values.
+
+2. Verify the deployment:
+
+```bash
+kubectl get deployments
+kubectl get svc
+```
+
+Ensure the deployment `<release-name>-github-actions-cache-server` is running and the service is accessible.
+
+#### Customizing the Deployment
+
+To customize the deployment, you can override the default values by creating a `values.yaml` file. 
+
+For all possible configuration options, refer to the [values.yaml file](https://github.com/falcondev-oss/github-actions-cache-server/blob/master/install/kubernetes/github-actions-cache-server/values.yaml).
+
+For more details on customizing Helm charts, see the [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing).
+
+Then install the chart with your custom values:
+
+```bash
+helm install <release-name> oci://ghcr.io/falcondev-oss/charts/github-actions-cache-server -f values.yaml
 ```
 
 ### Environment Variables


### PR DESCRIPTION
This PR adds GitHub Actions job, releasing Helm chart as OCI artifact: https://helm.sh/docs/topics/registries/

OCI "images" reuse the same GHCR registry as main application image, prefixed with `charts/`, resulting charts will be published as `oci://ghcr.io/falcondev-oss/charts/github-actions-cache-server:<chart-version>`

Also added basic documentation about installing such Helm releases to resolve #128 
