### PR TITLE
Update deprecated orderBy usage

### DIFF
--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -106,7 +106,7 @@ export async function findKeyMatch(
     .selectFrom('cache_keys')
     .where('key', 'like', `${args.key}%`)
     .where('version', '=', args.version)
-    .orderBy('cache_keys.updated_at desc')
+    .orderBy('cache_keys.updated_at', 'desc')
     .selectAll()
     .executeTakeFirst()
 
@@ -124,7 +124,7 @@ export async function findKeyMatch(
     const exactMatch = await db
       .selectFrom('cache_keys')
       .where('id', '=', getCacheKeyId(key, args.version))
-      .orderBy('cache_keys.updated_at desc')
+      .orderBy('cache_keys.updated_at', 'desc')
       .selectAll()
       .executeTakeFirst()
     if (exactMatch) {
@@ -137,7 +137,7 @@ export async function findKeyMatch(
       .selectFrom('cache_keys')
       .where('version', '=', args.version)
       .where('key', 'like', `${key}%`)
-      .orderBy('cache_keys.updated_at desc')
+      .orderBy('cache_keys.updated_at', 'desc')
       .selectAll()
       .executeTakeFirst()
 

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -136,7 +136,7 @@ export const useStorageAdapter = createSingletonPromise(async () => {
           .selectFrom('upload_parts')
           .selectAll()
           .where('upload_id', '=', upload.id)
-          .orderBy('part_number asc')
+          .orderBy('part_number', 'asc')
           .execute()
 
         await db.transaction().execute(async (tx) => {


### PR DESCRIPTION
Found this in the logs:

```
`orderBy('column asc')` is deprecated. Use `orderBy('column', 'asc')` instead.
```

