### PR TITLE
feat: add dedicated /health endpoint for health checks

### DIFF
--- a/install/kubernetes/github-actions-cache-server/values.yaml
+++ b/install/kubernetes/github-actions-cache-server/values.yaml
@@ -73,11 +73,11 @@ resources:
 
 livenessProbe:
   httpGet:
-    path: /
+    path: /health
     port: cache
 readinessProbe:
   httpGet:
-    path: /
+    path: /health
     port: cache
 
 autoscaling:

--- a/routes/health.ts
+++ b/routes/health.ts
@@ -1,0 +1,4 @@
+export default defineEventHandler((event) => {
+  setResponseStatus(event, 200)
+  return 'healthy'
+})


### PR DESCRIPTION
- Add /health route that returns 'healthy' status
- Update liveness and readiness probes to use /health instead of /

Fixes #192