### PR TITLE
fix: use dynamic repository for Docker image path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,7 +77,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/falcondev-oss/github-actions-cache-server
+          images: ghcr.io/${{ github.repository }}
           tags: |
             dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/falcondev-oss/github-actions-cache-server
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}},value=${{ needs.release.outputs.RELEASE_TAG }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.RELEASE_TAG }}


### PR DESCRIPTION
- Replace hardcoded `ghcr.io/falcondev-oss/github-actions-cache-server` with `ghcr.io/${{ github.repository }}` in CI/CD workflows
- Allows Docker builds to work correctly in forked repositories