### PR TITLE
fix: use Azurite-compatible URL format for signed_upload_url

### DIFF
--- a/routes/devstoreaccount1/upload/[uploadId].put.ts
+++ b/routes/devstoreaccount1/upload/[uploadId].put.ts
@@ -1,0 +1,70 @@
+import type { ReadableStream } from 'node:stream/web'
+import { Buffer } from 'node:buffer'
+import { randomUUID } from 'node:crypto'
+
+import { z } from 'zod'
+import { logger } from '~/lib/logger'
+
+import { getStorage } from '~/lib/storage'
+
+const pathParamsSchema = z.object({
+  uploadId: z.coerce.number(),
+})
+
+export default defineEventHandler(async (event) => {
+  const parsedPathParams = pathParamsSchema.safeParse(event.context.params)
+  if (!parsedPathParams.success)
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Invalid path parameters: ${parsedPathParams.error.message}`,
+    })
+
+  if (getQuery(event).comp === 'blocklist') {
+    setResponseStatus(event, 201)
+    // prevent random EOF error with in tonistiigi/go-actions-cache caused by missing request id
+    setHeader(event, 'x-ms-request-id', randomUUID())
+    return
+  }
+
+  const blockId = getQuery(event)?.blockid as string
+  // if no block id, upload smaller than chunk size
+  const chunkIndex = blockId ? getChunkIndexFromBlockId(blockId) : 0
+  if (chunkIndex === undefined)
+    throw createError({
+      statusCode: 400,
+      statusMessage: `Invalid block id: ${blockId}`,
+    })
+
+  const { uploadId } = parsedPathParams.data
+
+  const stream = getRequestWebStream(event)
+  if (!stream) {
+    logger.debug('Upload: Request body is not a stream')
+    throw createError({ statusCode: 400, statusMessage: 'Request body must be a stream' })
+  }
+
+  const storage = await getStorage()
+  await storage.uploadPart(uploadId, chunkIndex, stream as ReadableStream)
+
+  // prevent random EOF error with in tonistiigi/go-actions-cache caused by missing request id
+  setHeader(event, 'x-ms-request-id', randomUUID())
+  setResponseStatus(event, 201)
+})
+
+function getChunkIndexFromBlockId(blockIdBase64: string) {
+  const base64Decoded = Buffer.from(blockIdBase64, 'base64')
+
+  // 64 bytes used by docker buildx
+  // 48 bytes used by everything else
+  if (base64Decoded.length === 64) {
+    return base64Decoded.readUInt32BE(16)
+  } else if (base64Decoded.length === 48) {
+    const decoded = base64Decoded.toString('utf8')
+
+    // slice off uuid and convert to number
+    const index = Number.parseInt(decoded.slice(36))
+    if (Number.isNaN(index)) return
+
+    return index
+  }
+}

--- a/routes/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry.post.ts
+++ b/routes/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry.post.ts
@@ -34,6 +34,6 @@ export default defineEventHandler(async (event) => {
 
   return {
     ok: true,
-    signed_upload_url: `${env.API_BASE_URL}/upload/${upload.id}`,
+    signed_upload_url: `${env.API_BASE_URL}/devstoreaccount1/upload/${upload.id}`,
   }
 })


### PR DESCRIPTION
## Problem

`actions/cache@v4.2.0+` (and any action using `@actions/cache` v4+) hardcodes `useAzureSdk: true` in `saveCacheV2()`. This passes the `signed_upload_url` returned by `CreateCacheEntry` to the Azure `BlobClient` constructor, which expects URLs in Azure Blob Storage format.

The current URL format:
```
{API_BASE_URL}/upload/{id}
```

…causes the Azure SDK to fail with:
```
Warning: Failed to save: Unable to extract blobName and containerName with provided information.
```

The upload handler already correctly handles Azure SDK requests (`comp=blocklist`, `blockid` query params), but the **URL format** prevents the `BlobClient` constructor from parsing it.

## Solution

Change the upload URL to use [Azurite-compatible format](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite):

```
{API_BASE_URL}/devstoreaccount1/upload/{id}
```

The Azure SDK recognizes `devstoreaccount1` as the Azurite storage emulator account name, and correctly extracts:
- `accountName`: `devstoreaccount1`
- `containerName`: `upload`
- `blobName`: `{id}`

The original `/upload/{id}` route is preserved for backward compatibility (e.g., `tonistiigi/go-actions-cache` used by Docker buildx).

## Changes

1. **`CreateCacheEntry.post.ts`**: Updated `signed_upload_url` to include `/devstoreaccount1` prefix
2. **`routes/devstoreaccount1/upload/[uploadId].put.ts`**: Added route handler at the Azurite-compatible path (identical to the existing upload handler)

## Testing

Tested with:
- `actions/cache@v4` (v4.3.0) — cache save succeeds
- `actions/setup-node@v4` with `cache: npm` — cache save succeeds
- Self-hosted ARC runners on GKE with GCS storage driver
- `enableDirectDownloads: true`

Fixes #203

Made with [Cursor](https://cursor.com)