### PR TITLE
fix(chart): include service port in default apiBaseUrl

### DIFF
--- a/install/kubernetes/github-actions-cache-server/templates/_helpers.tpl
+++ b/install/kubernetes/github-actions-cache-server/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Generate environment variables from config values.
 - name: PORT
   value: "3000"
 - name: API_BASE_URL
-  value: {{ default (printf "http://%s.%s.svc.cluster.local" (include "github-actions-cache-server.fullname" .) .Release.Namespace) .Values.config.apiBaseUrl | quote }}
+  value: {{ default (printf "http://%s.%s.svc.cluster.local:%v" (include "github-actions-cache-server.fullname" .) .Release.Namespace .Values.service.port) .Values.config.apiBaseUrl | quote }}
 - name: ENABLE_DIRECT_DOWNLOADS
   value: {{ .Values.config.enableDirectDownloads | quote }}
 - name: CACHE_CLEANUP_OLDER_THAN_DAYS


### PR DESCRIPTION
The default `API_BASE_URL` omits the service port, causing the server to return upload URLs pointing at port 80. On Kubernetes, connections to a ClusterIP on an undefined port are silently dropped by iptables, so cache uploads hang indefinitely at 0%.

This broke when the default service port changed from 80 to 3000 (see #215).

Fix: include `.Values.service.port` in the printf format so the default stays consistent with the configured service port.