### PR TITLE
fix: return 404 for stale cache entries with missing storage objects

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -30,6 +30,14 @@ import { match } from 'ts-pattern'
 import { getDatabase } from './db'
 import { env } from './env'
 import { generateNumberId } from './helpers'
+import { logger } from './logger'
+
+export class ObjectNotFoundError extends Error {
+  constructor(objectName: string) {
+    super(`Object not found in storage: ${objectName}`)
+    this.name = 'ObjectNotFoundError'
+  }
+}
 
 export class Storage {
   adapter
@@ -208,22 +216,24 @@ export class Storage {
       .where('id', '=', storageLocation.id)
       .execute()
 
-    if (storageLocation.mergedAt || storageLocation.mergeStartedAt)
-      return this.downloadFromCacheEntryLocation(storageLocation)
-
-    await this.db
-      .updateTable('storage_locations')
-      .set({
-        mergeStartedAt: Date.now(),
-      })
-      .where('id', '=', storageLocation.id)
-      .execute()
-
-    const responseStream = new PassThrough()
-    const mergerStream = new PassThrough()
-
     try {
-      const promise = this.adapter
+      if (storageLocation.mergedAt || storageLocation.mergeStartedAt)
+        return await this.downloadFromCacheEntryLocation(storageLocation)
+
+      await this.ensurePartsExist(storageLocation)
+
+      await this.db
+        .updateTable('storage_locations')
+        .set({
+          mergeStartedAt: Date.now(),
+        })
+        .where('id', '=', storageLocation.id)
+        .execute()
+
+      const responseStream = new PassThrough()
+      const mergerStream = new PassThrough()
+
+      const mergePromise = this.adapter
         .uploadStream(`${storageLocation.folderName}/merged`, mergerStream)
         .then(async () => {
           await this.db
@@ -255,31 +265,36 @@ export class Storage {
             .execute()
           mergerStream.destroy()
         })
-      this.mergeStreamPromises.add(promise)
-      promise.finally(() => this.mergeStreamPromises.delete(promise))
+      this.mergeStreamPromises.add(mergePromise)
+      mergePromise.finally(() => this.mergeStreamPromises.delete(mergePromise))
+
+      this.pumpPartsToStreams(storageLocation, responseStream, mergerStream).catch((err) => {
+        responseStream.destroy(err)
+        mergerStream.destroy(err)
+        if (err instanceof ObjectNotFoundError)
+          logger.warn(`Stale cache entry ${cacheEntryId}: ${err.message}`)
+      })
+
+      return responseStream
     } catch (err) {
-      await this.db
-        .updateTable('storage_locations')
-        .set({
-          mergedAt: null,
-          mergeStartedAt: null,
-        })
-        .where('id', '=', storageLocation.id)
-        .execute()
+      if (err instanceof ObjectNotFoundError) {
+        logger.warn(`Stale cache entry ${cacheEntryId}: ${err.message}`)
+        return
+      }
       throw err
     }
+  }
 
-    this.pumpPartsToStreams(storageLocation, responseStream, mergerStream).catch((err) => {
-      responseStream.destroy(err)
-      mergerStream.destroy(err)
-    })
-
-    return responseStream
+  private async ensurePartsExist(location: StorageLocation) {
+    const partsFolder = `${location.folderName}/parts`
+    const actualPartCount = await this.adapter.countFilesInFolder(partsFolder)
+    if (actualPartCount < location.partCount) throw new ObjectNotFoundError(partsFolder)
   }
 
   private async downloadFromCacheEntryLocation(location: StorageLocation) {
     if (location.mergedAt) return this.adapter.createDownloadStream(`${location.folderName}/merged`)
 
+    await this.ensurePartsExist(location)
     return Readable.from(this.streamParts(location))
   }
 
@@ -522,15 +537,20 @@ class S3Adapter implements StorageAdapter {
   }
 
   async createDownloadStream(objectName: string) {
-    const response = await this.s3.send(
-      new GetObjectCommand({
-        Bucket: this.bucket,
-        Key: `${this.keyPrefix}/${objectName}`,
-      }),
-    )
-    if (!response.Body) throw new Error('No body in S3 get object response')
+    try {
+      const response = await this.s3.send(
+        new GetObjectCommand({
+          Bucket: this.bucket,
+          Key: `${this.keyPrefix}/${objectName}`,
+        }),
+      )
+      if (!response.Body) throw new Error('No body in S3 get object response')
 
-    return response.Body as Readable
+      return response.Body as Readable
+    } catch (err: any) {
+      if (err.name === 'NoSuchKey') throw new ObjectNotFoundError(objectName)
+      throw err
+    }
   }
 
   async deleteFolder(folderName: string) {
@@ -629,7 +649,13 @@ class FileSystemAdapter implements StorageAdapter {
   }
 
   async createDownloadStream(objectName: string) {
-    return createReadStream(path.join(this.rootFolder, objectName))
+    const filePath = path.join(this.rootFolder, objectName)
+    try {
+      await fs.access(filePath)
+    } catch {
+      throw new ObjectNotFoundError(objectName)
+    }
+    return createReadStream(filePath)
   }
 
   async deleteFolder(folderName: string) {
@@ -656,11 +682,15 @@ class FileSystemAdapter implements StorageAdapter {
   }
 
   async countFilesInFolder(folderName: string) {
-    const dir = await fs.readdir(path.join(this.rootFolder, folderName), {
-      withFileTypes: true,
-    })
-
-    return dir.filter((item) => item.isFile()).length
+    try {
+      const dir = await fs.readdir(path.join(this.rootFolder, folderName), {
+        withFileTypes: true,
+      })
+      return dir.filter((item) => item.isFile()).length
+    } catch (err: any) {
+      if (err.code === 'ENOENT') return 0
+      throw err
+    }
   }
 }
 
@@ -690,7 +720,10 @@ class GcsAdapter implements StorageAdapter {
   }
 
   async createDownloadStream(objectName: string) {
-    return this.bucket.file(`${this.keyPrefix}/${objectName}`).createReadStream()
+    const file = this.bucket.file(`${this.keyPrefix}/${objectName}`)
+    const [exists] = await file.exists()
+    if (!exists) throw new ObjectNotFoundError(objectName)
+    return file.createReadStream()
   }
 
   async deleteFolder(folderName: string) {

--- a/tests/stale-cache.test.ts
+++ b/tests/stale-cache.test.ts
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { restoreCache, saveCache } from '@actions/cache'
+import { SignJWT } from 'jose'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { Storage } from '~/lib/storage'
+import { TEST_TEMP_DIR } from './setup'
+
+const testFilePath = path.join(TEST_TEMP_DIR, 'test-stale.bin')
+
+describe('stale cache entry handling (missing storage objects)', () => {
+  let adapter: Awaited<ReturnType<typeof Storage.getAdapterFromEnv>>
+
+  beforeAll(async () => {
+    process.env.ACTIONS_CACHE_SERVICE_V2 = 'true'
+    process.env.ACTIONS_RUNTIME_TOKEN = await new SignJWT({
+      ac: JSON.stringify([{ Scope: 'refs/heads/main', Permission: 3 }]),
+      repository_id: '123',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .sign(crypto.createSecretKey('mock-secret-key', 'ascii'))
+
+    adapter = await Storage.getAdapterFromEnv()
+  })
+  afterAll(() => {
+    delete process.env.ACTIONS_CACHE_SERVICE_V2
+    delete process.env.ACTIONS_RUNTIME_TOKEN
+  })
+
+  test(
+    'returns cache miss when parts are wiped before first download (unmerged entry)',
+    { timeout: 30_000 },
+    async () => {
+      const contents = crypto.randomBytes(1024)
+      await fs.writeFile(testFilePath, contents)
+      await saveCache([testFilePath], 'stale-fresh-key')
+      await fs.rm(testFilePath)
+
+      await adapter.clear()
+
+      const missKey = await restoreCache([testFilePath], 'stale-fresh-key')
+      expect(missKey).toBeUndefined()
+
+      const missKey2 = await restoreCache([testFilePath], 'stale-fresh-key')
+      expect(missKey2).toBeUndefined()
+    },
+  )
+
+  test(
+    'returns cache miss when the merged blob is wiped after merge completes',
+    { timeout: 30_000 },
+    async () => {
+      const contents = crypto.randomBytes(1024)
+      await fs.writeFile(testFilePath, contents)
+      await saveCache([testFilePath], 'stale-merged-key')
+      await fs.rm(testFilePath)
+
+      const hitKey = await restoreCache([testFilePath], 'stale-merged-key')
+      expect(hitKey).toBe('stale-merged-key')
+      await fs.rm(testFilePath)
+
+      // Wait for the background merge to flush before wiping storage.
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+
+      await adapter.clear()
+
+      const missKey = await restoreCache([testFilePath], 'stale-merged-key')
+      expect(missKey).toBeUndefined()
+
+      const missKey2 = await restoreCache([testFilePath], 'stale-merged-key')
+      expect(missKey2).toBeUndefined()
+    },
+  )
+})


### PR DESCRIPTION
Closes #222

## Problem

When a cache entry exists in the DB but its backing storage object has been lost (interrupted upload, manual deletion, lifecycle rule, partial bucket wipe), `GET /download/:cacheEntryId` threw an unhandled error and returned **500**. BuildKit's cache-import client retries on 500 and hangs the workflow instead of falling back to the upstream registry.

## Solution

Return **404** when the storage object is missing so clients treat it as a clean cache miss.

The download path has three branches based on `storage_locations.mergedAt` / `mergeStartedAt`:

- **Merged blob path** — `adapter.createDownloadStream(merged)` already awaits a synchronous existence check in each adapter, so errors surface before any response bytes are written. The outer `try/catch` just needs to recognize them.
- **Parts-streaming paths** (fresh entry and mergeStartedAt-but-not-merged) — these were lazy: the generator opened parts only when the consumer began reading, so a missing object would surface *after* the HTTP response was already framed as 200, truncating the client. Now pre-validated via `countFilesInFolder` before returning the response stream.

When a stale entry is detected, the server logs a warning and returns `undefined`; the route yields 404; the existing cleanup task reaps the row on its normal schedule. No DB mutation on the read path.

## Changes

- New typed `ObjectNotFoundError` raised by each adapter's `createDownloadStream` when the object is missing.
- New private `Storage.ensurePartsExist(location)` — uses `countFilesInFolder` to pre-probe before committing to an HTTP response.
- `Storage.download()` wraps the body in a single `try/catch` that converts `ObjectNotFoundError` into `undefined` (→ 404) and rethrows everything else.
- `FileSystemAdapter.countFilesInFolder` now returns `0` for a missing folder instead of throwing `ENOENT`, matching S3/GCS list-by-prefix semantics.
- Removed a dead inner `try/catch` around the merge-upload promise setup (`uploadStream` is `async`, so a sync throw isn't possible).

## Testing

- `pnpm run type-check` ✓
- `pnpm run lint` ✓
- `pnpm run test:run` ✓ (new tests pass under filesystem + sqlite locally; full 3×3 matrix runs in CI)

New `tests/stale-cache.test.ts` covers both parts-streaming paths by wiping storage through `Storage.getAdapterFromEnv()` so it runs under all three storage drivers in CI:

1. **Unmerged entry** — save → wipe → restore twice → expect cache miss (exercises \`ensurePartsExist\` with zero parts).
2. **Merged entry** — save → restore (triggers background merge) → wait for merge → wipe → restore twice → expect cache miss (exercises the synchronous existence check on the merged blob).

Representative server log from a run confirming the fix:

\`\`\`
[warn] Stale cache entry 4f31d42e-...: Object not found in storage: 1550524356/merged
[error] Response: GET /download/4f31d42e-... > 404
\`\`\`

## Notes

- No new dependencies.
- No schema changes.
- No changes to any public HTTP contract — stale entries now return 404 where they previously 500'd.