### PR TITLE
fix: fall back to next scope when no restore keys

### DIFF
--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -425,7 +425,7 @@ export class Storage {
           type: 'prefixed-primary' as const,
         }
 
-      if (restoreKeys.length === 0) return
+      if (restoreKeys.length === 0) continue
 
       for (const key of restoreKeys) {
         const exactMatch = await this.db


### PR DESCRIPTION
## Bug

A PR workflow that restores a cache gets a miss, even when an entry with the exact same key exists on the base branch scope.

Expected: the lookup should fall back from the PR scope (`refs/pull/N/merge`) to the base-branch scope (`refs/heads/main`) and return that entry.

## Impact

Every PR misses the base-branch cache and creates its own copy on first run. In one repo we observed 26 duplicate copies of the same key across PR scopes because fallback never kicked in.

## Fix

Change `return` to `continue` so the loop proceeds to the next scope.

## Test

No existing test covers multi-scope lookups without restore keys. Happy to add one if helpful — the current `tests/e2e.test.ts` uses a single scope so the bug doesn't surface there.