### PR TITLE
fix: return ok=false from cache lookup when storage is missing (follow-up to #223)

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,81 @@
+name: 🔬 Preview build
+
+# Manual-dispatch image build for testing branches before they land on dev.
+# Triggering on `fix/abort-kills-merge-and-cleanup-race` publishes
+# `ghcr.io/mpecan/gha-cache-server:preview-<short-sha>` so a downstream
+# deployment can pin it by digest. No lint/test gate — this is explicitly
+# for in-cluster validation of in-flight patches; the full CI still runs on
+# push and on the eventual PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-suffix:
+        description: "Optional extra tag suffix (appended after the short sha)"
+        required: false
+        default: ""
+
+concurrency:
+  group: preview-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 🚀 Build and push preview
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compute tags
+        id: tags
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH_SLUG=$(echo "${{ github.ref_name }}" | tr '/' '-')
+          SUFFIX="${{ inputs.tag-suffix }}"
+          TAGS="ghcr.io/${{ github.repository }}:preview-${SHORT_SHA}"
+          TAGS="${TAGS}
+          ghcr.io/${{ github.repository }}:preview-${BRANCH_SLUG}"
+          if [ -n "${SUFFIX}" ]; then
+            TAGS="${TAGS}
+          ghcr.io/${{ github.repository }}:preview-${SHORT_SHA}-${SUFFIX}"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+            echo "short_sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            BUILD_HASH=${{ steps.tags.outputs.short_sha }}
+
+      - name: Print digest
+        run: |
+          echo "Image digest: ${{ steps.build.outputs.digest }}"
+          echo
+          echo "Pin in a deployment with:"
+          echo "  image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}"

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -17,6 +17,7 @@ import {
   DeleteObjectsCommand,
   GetObjectCommand,
   HeadBucketCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   S3Client,
 } from '@aws-sdk/client-s3'
@@ -465,32 +466,59 @@ export class Storage {
   }
 
   async getCacheEntryWithDownloadUrl(args: Parameters<typeof this.matchCacheEntry>[0]) {
-    const cacheEntry = await this.matchCacheEntry(args)
-    if (!cacheEntry) return
+    // Retry matching: if the best match points at missing storage (e.g. the
+    // backend was wiped, or an upload never finalized), purge that entry and
+    // fall back to the next candidate. Without this, BuildKit gets a download
+    // URL that 404s mid-build instead of a clean cache miss.
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const cacheEntry = await this.matchCacheEntry(args)
+      if (!cacheEntry) return
 
-    const defaultUrl = `${env.API_BASE_URL}/download/${cacheEntry.match.id}`
+      const location = await this.db
+        .selectFrom('storage_locations')
+        .where('id', '=', cacheEntry.match.locationId)
+        .select(['folderName', 'mergedAt', 'partCount', 'partsDeletedAt'])
+        .executeTakeFirst()
 
-    if (!env.ENABLE_DIRECT_DOWNLOADS || !this.adapter.createDownloadUrl)
-      return {
-        downloadUrl: defaultUrl,
-        cacheEntry: cacheEntry.match,
+      if (!location || !(await this.storageHasData(location))) {
+        logger.warn(
+          `Cache entry ${cacheEntry.match.id} (${cacheEntry.match.key}) points at missing storage, purging.`,
+        )
+        await this.db.deleteFrom('cache_entries').where('id', '=', cacheEntry.match.id).execute()
+        continue
       }
 
-    const location = await this.db
-      .selectFrom('storage_locations')
-      .where('id', '=', cacheEntry.match.locationId)
-      .select(['folderName', 'mergedAt'])
-      .executeTakeFirst()
-    if (!location) throw new Error('Storage location not found')
+      const defaultUrl = `${env.API_BASE_URL}/download/${cacheEntry.match.id}`
 
-    const downloadUrl = location.mergedAt
-      ? await this.adapter.createDownloadUrl(`${location.folderName}/merged`)
-      : defaultUrl
+      if (!env.ENABLE_DIRECT_DOWNLOADS || !this.adapter.createDownloadUrl)
+        return {
+          downloadUrl: defaultUrl,
+          cacheEntry: cacheEntry.match,
+        }
 
-    return {
-      downloadUrl,
-      cacheEntry: cacheEntry.match,
+      const downloadUrl = location.mergedAt
+        ? await this.adapter.createDownloadUrl(`${location.folderName}/merged`)
+        : defaultUrl
+
+      return {
+        downloadUrl,
+        cacheEntry: cacheEntry.match,
+      }
     }
+  }
+
+  private async storageHasData(location: {
+    folderName: string
+    mergedAt: number | null
+    partCount: number
+    partsDeletedAt: number | null
+  }) {
+    if (location.mergedAt) return this.adapter.objectExists(`${location.folderName}/merged`)
+
+    if (location.partsDeletedAt) return false
+
+    const actualPartCount = await this.adapter.countFilesInFolder(`${location.folderName}/parts`)
+    return actualPartCount >= location.partCount
   }
 }
 
@@ -501,6 +529,7 @@ interface StorageAdapter {
   uploadStream(objectName: string, stream: Readable): Promise<void>
   deleteFolder(folderName: string): Promise<void>
   countFilesInFolder(folderName: string): Promise<number>
+  objectExists(objectName: string): Promise<boolean>
   createDownloadUrl?(objectName: string): Promise<string>
   clear(): Promise<void>
 }
@@ -627,6 +656,26 @@ class S3Adapter implements StorageAdapter {
     return listResponse.KeyCount ?? 0
   }
 
+  async objectExists(objectName: string) {
+    try {
+      await this.s3.send(
+        new HeadObjectCommand({
+          Bucket: this.bucket,
+          Key: `${this.keyPrefix}/${objectName}`,
+        }),
+      )
+      return true
+    } catch (err: any) {
+      if (
+        err.name === 'NotFound' ||
+        err.name === 'NoSuchKey' ||
+        err.$metadata?.httpStatusCode === 404
+      )
+        return false
+      throw err
+    }
+  }
+
   async createDownloadUrl(objectName: string) {
     return getSignedUrl(
       this.s3,
@@ -710,6 +759,15 @@ class FileSystemAdapter implements StorageAdapter {
       throw err
     }
   }
+
+  async objectExists(objectName: string) {
+    try {
+      await fs.access(this.safePath(objectName))
+      return true
+    } catch {
+      return false
+    }
+  }
 }
 
 class GcsAdapter implements StorageAdapter {
@@ -775,6 +833,11 @@ class GcsAdapter implements StorageAdapter {
         autoPaginate: true,
       })
       .then((res) => res[0].length)
+  }
+
+  async objectExists(objectName: string) {
+    const [exists] = await this.bucket.file(`${this.keyPrefix}/${objectName}`).exists()
+    return exists
   }
 
   async createDownloadUrl(objectName: string) {

--- a/tests/stale-cache.test.ts
+++ b/tests/stale-cache.test.ts
@@ -73,4 +73,37 @@ describe('stale cache entry handling (missing storage objects)', () => {
       expect(missKey2).toBeUndefined()
     },
   )
+
+  test(
+    'falls back to a valid restore key when the best match has missing storage',
+    { timeout: 30_000 },
+    async () => {
+      // Seed an entry we will later wipe from storage (keeping the DB row).
+      const staleContents = crypto.randomBytes(1024)
+      await fs.writeFile(testFilePath, staleContents)
+      await saveCache([testFilePath], 'restore-fallback-stale')
+      await fs.rm(testFilePath)
+
+      // Let any background merge settle before wiping storage.
+      await new Promise((resolve) => setTimeout(resolve, 2000))
+      await adapter.clear()
+
+      // Seed a second entry whose storage is intact. Because this row is the
+      // most recently updated, matchCacheEntry prefers 'restore-fallback-stale'
+      // (our first restore key) only if we put it first; to force the stale
+      // row to win we list it ahead of the valid one in restoreKeys.
+      const validContents = crypto.randomBytes(1024)
+      await fs.writeFile(testFilePath, validContents)
+      await saveCache([testFilePath], 'restore-fallback-valid')
+      await fs.rm(testFilePath)
+
+      // Primary miss, restore keys: stale first (DB row but no storage), then valid.
+      // The fix must purge the stale row and fall through to the valid one.
+      const hitKey = await restoreCache([testFilePath], 'restore-fallback-missing-primary', [
+        'restore-fallback-stale',
+        'restore-fallback-valid',
+      ])
+      expect(hitKey).toBe('restore-fallback-valid')
+    },
+  )
 })


### PR DESCRIPTION
Follow-up to #223, which returned **404** from `/download/:cacheEntryId` when the backing storage object was missing. That fix resolved the 500/hang for clients that retry on 5xx and fall back on 4xx — notably the `@actions/cache` library used by GitHub Actions workflows.

## Problem

Container-build tooling (BuildKit's GHA cache-import, at minimum) treats **any** non-200 response on the download URL as a hard build failure, not a cache miss. Concretely:

```
COPY api/ api/
ERROR: failed to copy: GET http://gha-cache-server/download/<uuid>
RESPONSE 404: 404 Server Error
```

The workflow aborts instead of rebuilding from source. After #223 landed, workflows that previously hung now fail fast with the same net effect: broken builds whenever an entry's storage is out-of-sync with the DB (bucket wipe, lifecycle-deleted object, unfinalized upload).

The cache-miss signal that BuildKit (and any spec-conforming client) actually observes is `ok: false` from the twirp `GetCacheEntryDownloadURL` lookup — **not** a 404 on the download URL it was handed. As long as the lookup returns a download URL, the client has committed to downloading, and any error at that stage is a failure.

## Solution

Validate storage availability in `Storage.getCacheEntryWithDownloadUrl` **before** handing back a download URL. If the matched entry's storage is missing, purge the stale `cache_entries` row and re-run `matchCacheEntry` so restore keys can still fall through to a valid candidate. If no valid match remains, return `undefined` → the route returns `{ ok: false }` → the client treats it as a clean cache miss.

This also self-heals the DB proactively rather than leaving cleanup to the 30-day `cleanup:cache-entries` task, so repeated workflow runs don't keep rediscovering the same stale row.

## Changes

- **New `StorageAdapter.objectExists(objectName)`** on S3 (`HeadObjectCommand`), filesystem (`fs.access`), and GCS (`file.exists()`). Used for merged-blob existence checks — cheaper than `countFilesInFolder` on a single object.
- **`Storage.storageHasData(location)`** private helper: returns `true` iff `mergedAt` is set and the merged blob exists, or no merge has happened and `partCount` matches what's on disk. `partsDeletedAt` with no `mergedAt` implies data loss → returns `false`.
- **`Storage.getCacheEntryWithDownloadUrl`** now loops (bounded at 10 attempts): on each iteration it matches, validates the match's storage, and — if invalid — deletes the `cache_entries` row and retries. First valid match wins; no valid match → `undefined`.
- **Test: `falls back to a valid restore key when the best match has missing storage`** — saves a stale entry, wipes storage, saves a valid entry, then asserts that a restore with the stale key listed first still returns the valid one. Exercises the retry loop and the cross-key fallback.

## Downsides / trade-offs

- One extra storage call per lookup (HEAD for merged, LIST for parts). Negligible on S3/GCS; slightly more noticeable on filesystem but still sub-millisecond.
- Self-healing on the read path (`DELETE FROM cache_entries`) was deliberately avoided in #223. Reintroducing it here is the minimum needed to keep a single lookup well-formed for clients that can't retry at a higher level — BuildKit chief among them. The cleanup task remains the backstop for orphaned `storage_locations`.
- Bounded retry (10) guards against a pathological scan if a flood of stale rows exists for the same prefix. In practice, one or two iterations suffice.

## Testing

- `pnpm run type-check` ✓
- `pnpm run lint` ✓
- `pnpm run test:run` ✓ — 8/8 pass including the new case and the two from #223.

Representative server log confirming the fix on a real BuildKit request (Garage-backed S3, post-bucket-wipe):

```
[warn] Cache entry 7cd91bc9-... (setup-rust-linux-x86_64-cargo) points at missing storage, purging.
[debug] Response: POST /twirp/github.actions.results.api.v1.CacheService/GetCacheEntryDownloadURL > 200 {"ok":false}
```

The workflow then builds from source as expected instead of aborting on 404.

## Notes

- No schema changes.
- No public HTTP contract changes — stale entries now cause the lookup to respond `{ ok: false }` where (after #223) the lookup would have succeeded and then the download would have 404'd.