### PR TITLE
feat(storage/s3): make S3 socket timeout configurable

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -8,6 +8,7 @@ export const envStorageDriverSchema = type.or(
     'AWS_ENDPOINT_URL?': 'string.url',
     'AWS_ACCESS_KEY_ID?': 'string',
     'AWS_SECRET_ACCESS_KEY?': 'string',
+    'STORAGE_S3_SOCKET_TIMEOUT_MS': 'number = 10000',
   },
   {
     STORAGE_DRIVER: type.unit('filesystem'),

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -527,7 +527,7 @@ class S3Adapter implements StorageAdapter {
       region: env.AWS_REGION,
       requestHandler: new NodeHttpHandler({
         httpsAgent: agent,
-        socketTimeout: 3000,
+        socketTimeout: env.STORAGE_S3_SOCKET_TIMEOUT_MS,
       }),
     })
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -77,6 +77,7 @@ const TESTING_ENV_BY_STORAGE_DRIVER = {
     AWS_ACCESS_KEY_ID: 'minioadmin',
     AWS_SECRET_ACCESS_KEY: 'minioadmin',
     AWS_ENDPOINT_URL: 'http://localhost:9000',
+    STORAGE_S3_SOCKET_TIMEOUT_MS: 10000,
   },
   gcs: {
     STORAGE_DRIVER: 'gcs',


### PR DESCRIPTION
## Problem

The S3 client uses a hardcoded `socketTimeout: 3000` (ms), introduced in d682bc0 ("perf: reduce memory usage by using node streams") together with stream-based downloads.

Because this timeout applies to the GetObject **body** socket, any pause longer than 3s in `pumpPartsToStreams` (`lib/storage.ts`) — caused by backpressure from either the response stream or the merge upload (`mergerStream`, `partSize: 5MB`, `queueSize: 1`) — aborts the in-flight S3/R2 socket with `ECONNRESET`. The handler has already streamed the headers, so Nitro then surfaces an unhandled `H3Error: aborted` followed by `ERR_HTTP_HEADERS_SENT`.

This is reproducible on R2 with non-trivial caches: the very first download of any cache entry always proxies through the server (since `mergedAt` is null until the merge finishes), and 3s of stalled read while backpressure resolves is easy to hit.

## Fix

Expose `STORAGE_S3_SOCKET_TIMEOUT_MS` so deployments hitting this can raise the limit without forking. Default raised to `10000` to give backpressure pauses more headroom on first-download proxy paths.

## Notes

- Single-line behavior change in `lib/storage.ts`; new env entry in `lib/schemas.ts`.
- No changes needed to docs/values; users only override this when they need to tune it further.