### PR TITLE
chore(helm): configurable lifecycle, terminationGracePeriodSeconds and autoscaling behavior

### DIFF
--- a/install/kubernetes/github-actions-cache-server/Chart.yaml
+++ b/install/kubernetes/github-actions-cache-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -54,6 +57,10 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or (eq $pvcEnabled "true") .Values.extraVolumeMounts }}
           volumeMounts:
           {{- if eq $pvcEnabled "true" }}

--- a/install/kubernetes/github-actions-cache-server/templates/hpa.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: {{ include "github-actions-cache-server.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
     {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/install/kubernetes/github-actions-cache-server/values.yaml
+++ b/install/kubernetes/github-actions-cache-server/values.yaml
@@ -217,6 +217,25 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
+  # -- Scaling behavior for the HPA (`spec.behavior`), passed through verbatim.
+  # Empty by default, so Kubernetes applies its own defaults.
+  # Useful to damp scale-down flapping, e.g.
+  # `scaleDown: {stabilizationWindowSeconds: 900, policies: [{type: Pods, value: 1, periodSeconds: 300}]}`.
+  behavior: {}
+
+# -- Container lifecycle hooks (`lifecycle`), passed through verbatim.
+# Empty by default. A `preStop` hook is the usual way to let in-flight requests
+# finish: the container keeps serving while the Service endpoint removal
+# propagates to ingress controllers, which is asynchronous. For example
+# `preStop: {exec: {command: [/bin/sh, -c, sleep 30]}}` — pair it with a
+# terminationGracePeriodSeconds larger than the sleep, or the kubelet will
+# SIGKILL the container mid-hook.
+lifecycle: {}
+
+# -- Grace period for pod termination (`terminationGracePeriodSeconds`).
+# Empty by default, so Kubernetes applies its default of 30.
+# Must exceed any `lifecycle.preStop` sleep above.
+terminationGracePeriodSeconds: ''
 
 # -- Pod Disruption Budget configuration.
 # Disabled by default. When enabled, defaults to maxUnavailable: 1.


### PR DESCRIPTION
Adds three pass-through values so the chart can express graceful pod shutdown and HPA scaling behavior:

| Value | Renders into | Default |
|---|---|---|
| `lifecycle` | container `lifecycle` | `{}` |
| `terminationGracePeriodSeconds` | pod `terminationGracePeriodSeconds` | `''` |
| `autoscaling.behavior` | HPA `spec.behavior` | `{}` |

All three default to empty, so **rendered output is unchanged for existing users**.

## Motivation

Without a `preStop` hook there's no way to drain a pod gracefully. That matters more than it might seem, because **HPA scale-down deletes pods directly rather than through the eviction API**, so a `PodDisruptionBudget` doesn't apply to it.

On our deployment of this chart behind an ingress controller, that produced **HTTP 504s on every scale-down**: the container got SIGTERM while the ingress was still routing to it, because Service endpoint removal is asynchronous. Correlation was unambiguous — the HPA oscillated `2→4→2`, and 504 bursts landed only in the scale-*down* windows, never on scale-up, with no OOMKills, no restarts and clean application logs.

A `preStop` sleep keeps the pod serving until endpoint removal propagates, and `autoscaling.behavior` lets operators damp the oscillation that triggers a drain in the first place. These were the only knobs missing to fix it from values — everything else needed was already configurable.

## Example

```yaml
terminationGracePeriodSeconds: 60
lifecycle:
  preStop:
    exec:
      command: ["/bin/sh", "-c", "sleep 30"]
autoscaling:
  enabled: true
  behavior:
    scaleDown:
      stabilizationWindowSeconds: 900
      policies:
        - type: Pods
          value: 1
          periodSeconds: 300
```

`terminationGracePeriodSeconds` should exceed any `preStop` sleep, or the kubelet SIGKILLs the container mid-hook. Both notes are in the values comments.

## Verification

- `helm lint` clean.
- **Backward compatibility:** `helm template` with default values, diffed against the previous chart — identical apart from the `helm.sh/chart` version label.
- All three values render into the expected fields.
- Rendered objects accepted by a **Kubernetes 1.35** API server via `kubectl apply --dry-run=server`.

Chart version `1.2.0` → `1.3.0` (additive, no breaking change), following the convention from #258.

Happy to adjust naming or placement — I put `lifecycle` and `terminationGracePeriodSeconds` next to `podDisruptionBudget` since they're all pod-lifecycle concerns, and `behavior` inside the existing `autoscaling` block.