### PR TITLE
feat(helm): add support for extra init containers to the Deployment

### DIFF
--- a/install/kubernetes/github-actions-cache-server/Chart.yaml
+++ b/install/kubernetes/github-actions-cache-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
+++ b/install/kubernetes/github-actions-cache-server/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
       {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints: {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
       {{- end }}
+      {{- with .Values.extraInitContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/install/kubernetes/github-actions-cache-server/values.yaml
+++ b/install/kubernetes/github-actions-cache-server/values.yaml
@@ -299,3 +299,12 @@ extraVolumeMounts: []
   # - name: custom-secret
   #   mountPath: /etc/secrets
   #   readOnly: true
+
+# Extra init containers to add to the pod.
+extraInitContainers: []
+  # - name: cloud-sql-proxy
+  #   image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2
+  #   restartPolicy: Always
+  #   args:
+  #     - --auto-iam-authn
+  #     - <project>:<region>:<instance>


### PR DESCRIPTION
### Context

Running the service in GCP with a CloudSQL instance with IAM authentication enabled for a secret-less deployment.
The lack of input(s) to push Google's `cloud-sql-proxy`, that is requires for this setup, forced us to have it deployed as a standalone Deployment. Making the setup way less secure that it ought to be.

### Changes

This PR allows operators to push any sidecars they would need via a new `extraInitContainers` option.
And accept the standard `InitiContainer` stanza as input.